### PR TITLE
ci: ensures release touches at least one file

### DIFF
--- a/build-bin/helm/helm_prepare
+++ b/build-bin/helm/helm_prepare
@@ -14,6 +14,9 @@
 #
 
 # This script prepares the helm chart for a release by updating the versions in the chart file.
+#
+# Note: helm/chart-releaser-action silently fails if there is no change made here.
+# Hence, we should never update the chart version manually.
 
 trigger_tag=${1?trigger_tag is required. Ex release-1.2.3}
 release_version=$(build-bin/git/version_from_trigger_tag release- ${trigger_tag})
@@ -39,9 +42,7 @@ sh -c "sed -i 's/appVersion\:\s[0-9.]\+/appVersion\: ${latest_app_version}/g' ./
 sh -c "sed -i 's/version\:\s[0-9.]\+/version\: ${release_version}/g' ./charts/zipkin/Chart.yaml"
 
 # Commit changes to ./charts/zipkin/Chart.yaml
-git add ./charts/zipkin/Chart.yaml
+git add ./charts/zipkin/Chart.yaml && git commit -m "release: zipkin-${release_version}"
 
-if git commit -m "release: updates for ${release_version}"; then
-  # Push the changes in ./charts/zipkin/Chart.yaml to the release branch
-  git push origin ${release_branch}
-fi
+# Push the changes in ./charts/zipkin/Chart.yaml to the release branch
+git push origin ${release_branch}

--- a/charts/zipkin/Chart.yaml
+++ b/charts/zipkin/Chart.yaml
@@ -14,7 +14,7 @@ appVersion: 3.0.6
 name: zipkin
 description: A Zipkin helm chart for kubernetes
 type: application
-version: 0.2.0
+version: 0.1.2  # chart version maintained by release automation
 maintainers:
   - name: openzipkin
     email: zipkin-dev@googlegroups.com


### PR DESCRIPTION
helm/chart-releaser-action silently fails if there is no change. So, it doesn't push the tag or the change to gh-pages/

Hence, we should never update the chart version manually, so this forces a change and clarifies we should not touch the chart version ourselves as long as we continue using that action.