### PR TITLE
List on Artifacthub: add initial artifacthub-repo.yml to claim repository ownership

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,5 @@
+owners:
+  - name: reta
+    email: drreta@gmail.com
+  - name: openzipkin
+    email: zipkin-dev@googlegroups.com


### PR DESCRIPTION
The Artifacthub package https://artifacthub.io/packages/helm/zipkin/zipkin refers to https://zipkin.io/zipkin-helm repository, adding the artifacthub-repo.yml over there so it could be discovered by Artifacthub