### PR TITLE
fix: HPA v2 spec

### DIFF
--- a/charts/zipkin/templates/hpa.yaml
+++ b/charts/zipkin/templates/hpa.yaml
@@ -31,12 +31,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
The spec for the HorizontalPodAutoscaler resource does not work on recent Kubernetes clusters (tested on 1.30).

It fails with:

> strict decoding error: unknown field "spec.metrics[0].resource.targetAverageUtilization"

