### PR TITLE
feat: allow deployment of zipkin-gcp collector

### DIFF
--- a/charts/zipkin/values.schema.json
+++ b/charts/zipkin/values.schema.json
@@ -278,7 +278,7 @@
                             "required": ["hosts"]
                         },
                         "type": {
-                            "enum": ["mem", "elasticsearch"]
+                            "enum": ["mem", "elasticsearch", "stackdriver"]
                         }
                     },
                     "anyOf": [
@@ -293,6 +293,12 @@
                                 "type": {"const": "elasticsearch"}
                             },
                             "required": ["elasticsearch"]
+                        },
+                        {
+                            "properties": {
+                                "type": {"const": "stackdriver"}
+                            },
+                            "required": []
                         }
                     ]
                 },


### PR DESCRIPTION
The schema update allows this helm chart to be used to deploy the zipkin-gcp collector.
