### PR TITLE
extraManifests type mismatch

### DIFF
--- a/charts/zipkin/values.schema.json
+++ b/charts/zipkin/values.schema.json
@@ -311,7 +311,7 @@
             }
         },
         "extraManifests": {
-            "type": "object"
+            "type": "array"
         }
     }
 }


### PR DESCRIPTION
Not setting any values for `extraManifests` broke chart installation process, because the type was invalid.

Before change:

```
$ helm lint charts/zipkin/
==> Linting charts/zipkin/
[INFO] Chart.yaml: icon is recommended
[ERROR] values.yaml: - extraManifests: Invalid type. Expected: object, given: array

[ERROR] templates/: values don't meet the specifications of the schema(s) in the following chart(s):
zipkin:
- extraManifests: Invalid type. Expected: object, given: array
```

After change:

```
$ helm lint charts/zipkin/
==> Linting charts/zipkin/
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```