### PR TITLE
Deployment: add quoting for extraEnv.

### DIFF
--- a/charts/zipkin/templates/deployment.yaml
+++ b/charts/zipkin/templates/deployment.yaml
@@ -108,7 +108,7 @@ spec:
             {{- end }}
             {{- range $key, $value := .Values.zipkin.extraEnv }}
             - name: {{ $key }}
-              value: {{ $value }}
+              value: {{ $value | quote }}
             {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:


### PR DESCRIPTION
This is required for extraEnv values ​​such as JAVA_OPTS: "-Xms512m -Xmx1024m -XX:+ExitOnOutOfMemoryError".