### PR TITLE
Update all CI dependencies

### DIFF
--- a/.github/ct.yml
+++ b/.github/ct.yml
@@ -1,1 +1,2 @@
 check-version-increment: false
+target-branch: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Prevent use of implicit GitHub Actions read-only token GITHUB_TOKEN.
           token: ${{ secrets.GH_TOKEN }}
@@ -24,12 +24,13 @@ jobs:
           git config user.email "zipkinci+zipkin-dev@googlegroups.com"
 
       - name: Get latest zipkin version
-        uses: oprypin/find-latest-tag@v1
-        with:
-          repository: openzipkin/zipkin
-          releases-only: true
-          regex: '^\d+\.\d+\.\d+$'
         id: appVersion
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG=$(gh release list --repo openzipkin/zipkin --exclude-drafts --exclude-pre-releases \
+            -L 100 --json tagName --jq '[.[] | select(.tagName | test("^\\d+\\.\\d+\\.\\d+$"))][0].tagName')
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Prepare release
         env:
@@ -45,7 +46,7 @@ jobs:
           build-bin/helm/helm_prepare $(echo ${GITHUB_REF} | cut -d/ -f 3) ${{ steps.appVersion.outputs.tag }}
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -54,7 +55,7 @@ jobs:
         run: echo "tag=$(echo ${GITHUB_REF} | cut -d/ -f 3)" >> $GITHUB_OUTPUT
 
       - name: Removes trigger target
-        uses: dev-drprasad/delete-tag-and-release@v1.0
-        with:
-          tag_name: ${{ steps.trigger-tag.outputs.tag }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete ${{ steps.trigger-tag.outputs.tag }} --cleanup-tag --yes 2>&1 || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: '0'  # to see origin/master
 
@@ -31,23 +31,22 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
-          version: v3.14.1
+          version: v3.20.1
 
       - name: Install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
       - name: Set up chart-testing
-        # See please https://github.com/helm/chart-testing-action/issues/140
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@v2.8.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed)
+          changed=$(ct list-changed --config .github/ct.yml)
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
@@ -57,11 +56,15 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.10.0
+        uses: helm/kind-action@v1.14.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Setup helmfile
-        uses: mamezou-tech/setup-helmfile@v2.0.0
+        uses: mamezou-tech/setup-helmfile@v2.2.0
+        with:
+          helm-diff-plugin-version: v3.15.3
+          install-helm: no
+          install-kubectl: no
 
       - name: Install prometheus
         run: helmfile -f charts/zipkin/ci/helmfile.yaml sync
@@ -69,4 +72,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install
+        run: ct install --config .github/ct.yml


### PR DESCRIPTION
The test workflow broke because setup-helmfile@v2.0.0 installs helm-diff from master, which added a field Helm v3.14.1 can't parse.

While fixing this, updates all actions to current versions and moves to node24 ahead of the June 2026 forced migration. Replaces two third-party actions (archived dev-drprasad/delete-tag-and-release and node20-only oprypin/find-latest-tag) with equivalent gh CLI commands.